### PR TITLE
[Tests] Add fuzz test for UInt32ToBytes

### DIFF
--- a/block_fuzz_test.go
+++ b/block_fuzz_test.go
@@ -1,1 +1,27 @@
 package bc
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// FuzzUInt32ToBytes ensures UInt32ToBytes correctly round-trips values.
+// The function converts a uint32 to little-endian bytes.  Fuzzing verifies
+// that converting back using the standard library yields the original value.
+func FuzzUInt32ToBytes(f *testing.F) {
+	f.Add(uint32(0))
+	f.Add(uint32(1))
+	f.Add(uint32(123456))
+	f.Add(^uint32(0))
+
+	f.Fuzz(func(t *testing.T, v uint32) {
+		b := UInt32ToBytes(v)
+		if len(b) != 4 {
+			t.Fatalf("unexpected length %d", len(b))
+		}
+		round := binary.LittleEndian.Uint32(b)
+		if round != v {
+			t.Fatalf("round trip failed: %d != %d", v, round)
+		}
+	})
+}


### PR DESCRIPTION
## What Changed
- Added fuzz test `FuzzUInt32ToBytes` verifying `UInt32ToBytes` round-trips values using little-endian decoding.

## Why It Was Necessary
- Provides fuzz coverage for a small utility function and ensures it behaves correctly for random inputs.

## Testing Performed
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`
- `make run-fuzz-tests`

## Impact / Risk
- Low risk, test only. No production code changes.

------
https://chatgpt.com/codex/tasks/task_e_6866dd2d5fcc832181c051a98b535732